### PR TITLE
fix: 🐞 (`website`) チャットUIでツール呼び出しが失敗した時に表示が切り替わるように修正した。(#22)

### DIFF
--- a/apps/website/src/common/types/chat.ts
+++ b/apps/website/src/common/types/chat.ts
@@ -17,6 +17,7 @@ export const tools = {
       date: z.string().describe('The date the item was lost. (e.g., YYYY-MM-DD)'), // 日付形式の例を追記
     }),
     result: z.object({
+      message: z.string().optional().describe('The message to the chat ai.'),
       lostItem: z
         .object({
           id: z.string(),

--- a/apps/website/src/module/search/search-lost-item-section/component/tool-invocation/tool-invocation.presenter.tsx
+++ b/apps/website/src/module/search/search-lost-item-section/component/tool-invocation/tool-invocation.presenter.tsx
@@ -75,7 +75,7 @@ export const ToolInvocation = <T extends ToolName>({ toolInvocation, onClaim }: 
         if (!lostItem) {
           return (
             <div className="my-2 flex w-full flex-col items-center gap-4 rounded-xl bg-sage-3 p-2 text-sm italic text-sage-11">
-              No items similar to &quot;{args.description}&quot; lost around {args.date} were found.
+              No items similar to &quot;{args.description}&quot; lost around {args.date} were found. {result.message}
             </div>
           );
         }


### PR DESCRIPTION
- close #22

## ツール呼び出し

エラーがthrowされた時に、エラーメッセージがLLMに渡されるようにした。

<img width="603" alt="image" src="https://github.com/user-attachments/assets/ff85db7f-bca2-4210-b909-a8827fdbeea1" />

## 入力欄

レスポンスの待機中は`disabled`になるように変更した。

<img width="599" alt="image" src="https://github.com/user-attachments/assets/2caf23aa-3dae-4432-99f5-57643796a2eb" />

